### PR TITLE
Add release script

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ const response = await apiFetch( {
 
 ### Deploying
 
+Prerequisites:
+
+- [Hub](https://github.com/github/hub)
+- Write access to this repository
+
 You can create a test ZIP of the plugin using this command:
 
 ```

--- a/README.md
+++ b/README.md
@@ -104,3 +104,21 @@ const response = await apiFetch( {
     method: 'POST',
 } );
 ```
+
+### Deploying
+
+You can create a test ZIP of the plugin using this command:
+
+```
+npm run build
+```
+
+This creates `woocommerce-admin-test-helper.zip` in the project root.
+
+We release the plugin using GitHub Releases. There is a script to automate this:
+
+0. Make sure the version is updated in `woocommerce-admin-test-helper.php`
+1. Commit and push to `trunk`
+2. Run `npm run release`
+3. Make sure you provide the correct version number when prompted
+4. That's it!

--- a/bin/build-zip.sh
+++ b/bin/build-zip.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+rm woocommerce-admin-test-helper.zip
+
+echo "Building"
+npm run build
+
+echo "Creating archive... 🎁"
+zip -r "woocommerce-admin-test-helper.zip" \
+	woocommerce-admin-test-helper.php \
+	plugin.php \
+	build/ \
+	api/ \
+	README.md

--- a/bin/release-to-github.sh
+++ b/bin/release-to-github.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+if ! [ -x "$(command -v hub)" ]; then
+  echo 'Error: hub is not installed. Install from https://github.com/github/hub' >&2
+  exit 1
+fi
+
+if [[ $1 == '' || $2 == '' ]]
+  then
+    output 1 "Please supply a tag and zip file name"
+    exit 1
+fi
+
+echo "Releasing to GitHub"
+echo "==================="
+echo "Before proceeding:"
+echo " • Make sure you have updated the plugin version in woocommerce-admin-test-helper.php"
+echo " • Ensure you have checked out the branch you wish to release"
+echo " • Ensure you have committed/pushed all local changes"
+echo " • Did you remember to update changelogs, the readme and plugin files?"
+echo
+echo "Do you want to continue? [y/N]: "
+read -r PROCEED
+echo
+
+if [ "$(echo "${PROCEED:-n}" | tr "[:upper:]" "[:lower:]")" != "y" ]; then
+  echo "Release cancelled!"
+  exit 1
+fi
+
+echo "What version do you want to release as? (make sure this matches the version in woocommerce-admin-test-helper.php)"
+read -r VERSION
+
+CURRENTBRANCH="$(git rev-parse --abbrev-ref HEAD)"
+
+if [ ! -d "dist" ]; then
+	echo "Dist directory not found. Aborting."
+	exit 1
+fi
+
+echo "Starting release to GitHub..."
+echo
+
+# Create a release branch.
+BRANCH="build/${VERSION}"
+git checkout -b $BRANCH
+
+# Force add build directory and commit.
+git add build/. --force
+git add .
+git commit -m "Adding /build directory to release" --no-verify
+
+# Push branch upstream
+git push origin $BRANCH
+
+# Create the zip archive
+./bin/build-zip.sh
+
+# Create the new release.
+hub release create -m $VERSION -m "Release of version $VERSION." -t $BRANCH "v${VERSION}" --attach "./woocommerce-admin-test-helper.zip"
+
+git checkout $CURRENTBRANCH
+git branch -D $BRANCH
+git push origin --delete $BRANCH
+
+echo "GitHub release complete."
+

--- a/bin/release-to-github.sh
+++ b/bin/release-to-github.sh
@@ -5,12 +5,6 @@ if ! [ -x "$(command -v hub)" ]; then
   exit 1
 fi
 
-if [[ $1 == '' || $2 == '' ]]
-  then
-    output 1 "Please supply a tag and zip file name"
-    exit 1
-fi
-
 echo "Releasing to GitHub"
 echo "==================="
 echo "Before proceeding:"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
 		"packages-update": "wp-scripts packages-update",
 		"start": "wp-scripts start",
 		"test:e2e": "wp-scripts test-e2e",
-		"test:unit": "wp-scripts test-unit-js"
+		"test:unit": "wp-scripts test-unit-js",
+		"zip": "./bin/build-zip.sh"
 	},
 	"devDependencies": {
 		"@woocommerce/dependency-extraction-webpack-plugin": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 		"start": "wp-scripts start",
 		"test:e2e": "wp-scripts test-e2e",
 		"test:unit": "wp-scripts test-unit-js",
-		"zip": "./bin/build-zip.sh"
+		"zip": "./bin/build-zip.sh",
+		"release": "./bin/release-to-github.sh"
 	},
 	"devDependencies": {
 		"@woocommerce/dependency-extraction-webpack-plugin": "1.4.0",

--- a/woocommerce-admin-test-helper.php
+++ b/woocommerce-admin-test-helper.php
@@ -5,7 +5,7 @@
  * Description: A helper plugin to assist with testing WooCommerce Admin
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
- * Version: 0.1.0-dev
+ * Version: 0.1.0
  *
  * @package WooCommerce\Admin\TestHelper
  */


### PR DESCRIPTION
Fixes #9 

This adds two commands:

- `npm run build` - this builds a plugin ZIP as `woocommerce-admin-test-helper.zip` which can be distributed and uploaded to test servers without creating a release
- `npm run release` - this builds the plugin and releases it via [GitHub Releases](https://github.com/woocommerce/woocommerce-admin-test-helper/releases)

Test instructions:

1. checkout this branch
2. update the version in `woocommerce-admin-test-helper.php` to `0.2.0`
3. `npm run build` and test out the generated zip
3. `npm run release`
4. test out the release via https://github.com/woocommerce/woocommerce-admin-test-helper/releases
5. make sure to delete the release once you're finished