### PR TITLE
Do not initialize the plugin if WC is not activated

### DIFF
--- a/woocommerce-admin-test-helper.php
+++ b/woocommerce-admin-test-helper.php
@@ -54,7 +54,15 @@ function add_extension_register_script() {
 	wp_enqueue_style( 'woocommerce-admin-test-helper' );
 }
 
-add_action( 'admin_enqueue_scripts', 'add_extension_register_script' );
+add_action( 'plugins_loaded', function() {
+	if ( ! defined( 'WC_PLUGIN_FILE' ) ) {
+		return;
+	}
+	
+	add_action( 'admin_enqueue_scripts', 'add_extension_register_script' );
 
-// Load the plugin
-require( 'plugin.php' );
+	// Load the plugin
+	require( 'plugin.php' );
+});
+
+


### PR DESCRIPTION
While testing the deactivation workflow of WC plugin, I noticed that `woocommerce-admin-test-helper` causes a fatal error when WC is deactivated.

### Steps to reproduce

1. Download the latest version of woocommerce-admin-test-helper. 
2. Activate both WooCommerce and woocommerce-admin-test-helper
3. Deactivate WooCommerce

This PR checks for `WC_PLUGIN_FILE` constant to load woocommerce-admin-test-helper conditionally.

