### PR TITLE
Add warning when tracking is disabled

### DIFF
--- a/src/experiments/index.js
+++ b/src/experiments/index.js
@@ -4,17 +4,45 @@
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { Button } from '@wordpress/components';
-
+import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 /**
  * Internal dependencies
  */
 import { STORE_KEY } from './data/constants';
 import './data';
 
-function Experiments( { experiments, toggleExperiment } ) {
+function Experiments( {
+	experiments,
+	toggleExperiment,
+	isTrackingEnabled,
+	isResolving,
+} ) {
+	if ( isResolving ) {
+		return null;
+	}
 	return (
 		<div id="wc-admin-test-helper-experiments">
 			<h2>Experiments</h2>
+			{ isTrackingEnabled === 'no' && (
+				<p className="tracking-disabled">
+					The following list might not be complete without tracking
+					enabled. <br />
+					Please visit&nbsp;
+					<a
+						target="_blank"
+						href={
+							wcSettings.adminUrl +
+							'/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com'
+						}
+						rel="noreferrer"
+					>
+						WooCommerce &#8594; Settings &#8594; Advanced &#8594;
+						Woocommerce.com
+					</a>
+					&nbsp;and check{ ' ' }
+					<b>Allow usage of WooCommerce to be tracked</b>.
+				</p>
+			) }
 			<table className="experiments wp-list-table striped table-view-list widefat">
 				<thead>
 					<tr>
@@ -61,8 +89,12 @@ function Experiments( { experiments, toggleExperiment } ) {
 export default compose(
 	withSelect( ( select ) => {
 		const { getExperiments } = select( STORE_KEY );
+		const { getOption, isResolving } = select( OPTIONS_STORE_NAME );
+
 		return {
 			experiments: getExperiments(),
+			isTrackingEnabled: getOption( 'woocommerce_allow_tracking' ),
+			isResolving: isResolving( 'getOption', [ 'getExperiments' ] ),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/src/index.scss
+++ b/src/index.scss
@@ -83,6 +83,13 @@
 	.components-notice {
 		margin: 0px 0px 10px 0px;
 	}
+	.tracking-disabled {
+		border: 1px solid #cc99c2;
+		border-left: 4px solid #cc99c2;
+		line-height: 1.5em;
+		background: #fff;
+		padding: 10px;
+	}
 }
 
 #wc-admin-test-helper-rest-api-filters {


### PR DESCRIPTION
Fixes #41 

This PR adds a warning in the experiments tab when `woocommerce_allow_tracking` is set to `no`

### Screenshots

![Screen Shot 2022-05-09 at 5 16 52 PM](https://user-images.githubusercontent.com/4723145/167518597-b0a9752e-3db8-4b4c-b70b-66b2842d1b07.jpg)


### Detailed test instructions

1. Navigate to `WooCommerce → Settings → Advanced → Woocommerce.com` and uncheck `Allow usage of WooCommerce to be tracked` and save the change.
2. Navigate to `Tools ->  WCA Test Helper -> Experiments`
3. You should see the warning message.
4. Go back to step #1 and enable the tracking.
5. Go back to step #2 and confirm no warning message.



