### PR TITLE
Update experiment cache time

### DIFF
--- a/src/experiments/data/actions.js
+++ b/src/experiments/data/actions.js
@@ -9,42 +9,42 @@ import { apiFetch } from '@wordpress/data-controls';
 import TYPES from './action-types';
 import { EXPERIMENT_NAME_PREFIX, TRANSIENT_NAME_PREFIX } from './constants';
 
-function toggleFrontendExperiment(experimentName, newVariation) {
+function toggleFrontendExperiment( experimentName, newVariation ) {
 	const storageItem = JSON.parse(
-		window.localStorage.getItem(EXPERIMENT_NAME_PREFIX + experimentName)
+		window.localStorage.getItem( EXPERIMENT_NAME_PREFIX + experimentName )
 	);
 
 	storageItem.variationName = newVariation;
 
 	window.localStorage.setItem(
 		EXPERIMENT_NAME_PREFIX + experimentName,
-		JSON.stringify(storageItem)
+		JSON.stringify( storageItem )
 	);
 }
 
-function* toggleBackendExperiment(experimentName, newVariation) {
+function* toggleBackendExperiment( experimentName, newVariation ) {
 	try {
 		const payload = {};
-		payload[TRANSIENT_NAME_PREFIX + experimentName] = newVariation;
-		yield apiFetch({
+		payload[ TRANSIENT_NAME_PREFIX + experimentName ] = newVariation;
+		yield apiFetch( {
 			method: 'POST',
 			path: '/wc-admin/options',
 			headers: { 'content-type': 'application/json' },
-			body: JSON.stringify(payload),
-		});
-	} catch (error) {
+			body: JSON.stringify( payload ),
+		} );
+	} catch ( error ) {
 		throw new Error();
 	}
 }
 
-export function* toggleExperiment(experimentName, currentVariation, source) {
+export function* toggleExperiment( experimentName, currentVariation, source ) {
 	const newVariation =
 		currentVariation === 'control' ? 'treatment' : 'control';
 
-	if (source === 'frontend') {
-		toggleFrontendExperiment(experimentName, newVariation);
+	if ( source === 'frontend' ) {
+		toggleFrontendExperiment( experimentName, newVariation );
 	} else {
-		yield toggleBackendExperiment(experimentName, newVariation);
+		yield toggleBackendExperiment( experimentName, newVariation );
 	}
 
 	return {
@@ -55,7 +55,7 @@ export function* toggleExperiment(experimentName, currentVariation, source) {
 	};
 }
 
-export function setExperiments(experiments) {
+export function setExperiments( experiments ) {
 	return {
 		type: TYPES.SET_EXPERIMENTS,
 		experiments,

--- a/src/experiments/data/actions.js
+++ b/src/experiments/data/actions.js
@@ -7,7 +7,11 @@ import { apiFetch } from '@wordpress/data-controls';
  * Internal dependencies
  */
 import TYPES from './action-types';
-import { EXPERIMENT_NAME_PREFIX, TRANSIENT_NAME_PREFIX } from './constants';
+import {
+	EXPERIMENT_NAME_PREFIX,
+	TRANSIENT_NAME_PREFIX,
+	TRANSIENT_TIMEOUT_NAME_PREFIX,
+} from './constants';
 
 function toggleFrontendExperiment( experimentName, newVariation ) {
 	const storageItem = JSON.parse(
@@ -15,6 +19,7 @@ function toggleFrontendExperiment( experimentName, newVariation ) {
 	);
 
 	storageItem.variationName = newVariation;
+	storageItem.ttl = 3600;
 
 	window.localStorage.setItem(
 		EXPERIMENT_NAME_PREFIX + experimentName,
@@ -26,6 +31,9 @@ function* toggleBackendExperiment( experimentName, newVariation ) {
 	try {
 		const payload = {};
 		payload[ TRANSIENT_NAME_PREFIX + experimentName ] = newVariation;
+		payload[ TRANSIENT_TIMEOUT_NAME_PREFIX + experimentName ] =
+			Math.round( Date.now() / 1000 ) + 3600;
+
 		yield apiFetch( {
 			method: 'POST',
 			path: '/wc-admin/options',

--- a/src/experiments/data/constants.js
+++ b/src/experiments/data/constants.js
@@ -1,4 +1,6 @@
 export const STORE_KEY = 'wc-admin-helper/experiments';
 export const EXPERIMENT_NAME_PREFIX = 'explat-experiment--';
 export const TRANSIENT_NAME_PREFIX = '_transient_abtest_variation_';
+export const TRANSIENT_TIMEOUT_NAME_PREFIX =
+	'_transient_timeout_abtest_variation';
 export const API_NAMESPACE = '/wc-admin-test-helper';


### PR DESCRIPTION
Fixes #43 

This PR updates cache expiration TTL for both frontend and backend to an hour.


### Detailed test instructions

1. Toggle a frontend experiment 
2. Open browser insepctor -> Application -> Local Storage 
3. Confirm the experiment has TTL value of 3600
4. Toggle a backend experiment
5. Open `wp_options` and search `_transient_timeout_abtest_variation` + the experiment name
6. Confirm the value is current time + an hour (approximately)

