### PR TITLE
Use \WC_Install class as Install class has been removed

### DIFF
--- a/api/tools/trigger-update-callbacks.php
+++ b/api/tools/trigger-update-callbacks.php
@@ -1,6 +1,5 @@
 <?php
 
-use Automattic\WooCommerce\Admin\Install;
 use Automattic\WooCommerce\Admin\API\Reports\Cache;
 
 register_woocommerce_admin_test_helper_rest_route(
@@ -26,7 +25,7 @@ register_woocommerce_admin_test_helper_rest_route(
 );
 
 function tools_get_wc_admin_versions() {
-	$db_updates  = Install::get_db_update_callbacks();
+	$db_updates  = \WC_Install::get_db_update_callbacks();
 
 	return new WP_REST_Response( array_keys( $db_updates ), 200 );
 }
@@ -37,7 +36,7 @@ function trigger_selected_update_callbacks( $request ) {
 		return;
 	}
 
-	$db_updates = Install::get_db_update_callbacks();
+	$db_updates = \WC_Install::get_db_update_callbacks();
 	$update_callbacks = $db_updates[ $version ];
 
 	foreach ( $update_callbacks as $update_callback ) {

--- a/api/tools/trigger-wca-install.php
+++ b/api/tools/trigger-wca-install.php
@@ -5,7 +5,7 @@ register_woocommerce_admin_test_helper_rest_route(
 );
 
 function tools_trigger_wca_install() {
-	Automattic\WooCommerce\Admin\Install::install();
+	\WC_Install::install();
 
 	return true;
 }


### PR DESCRIPTION
Fix fatal error with `Automattic\WooCommerce\Admin\Install` not being found (which doesn't exist anymore after merge). Made use of `WC_Install` instead.
<img width="1616" alt="Screen Shot 2022-05-27 at 10 19 34 AM" src="https://user-images.githubusercontent.com/2240960/170707207-490233b8-d9a2-458f-b94f-43aa08351cea.png">

### Screenshots

### Detailed test instructions

- Load this branch and run `npm run build`
- Go to **Tools > WCA Test Helper > Tools** and trigger the `wc_admin_daily_job` this should run successfully
- Now run the `Trigger WCA Install` task and make sure it runs successfully
